### PR TITLE
Retrieval of total position/progress ratio in transcoder

### DIFF
--- a/src/main/java/com/github/manevolent/ffmpeg4j/transcoder/Transcoder.java
+++ b/src/main/java/com/github/manevolent/ffmpeg4j/transcoder/Transcoder.java
@@ -2,6 +2,7 @@ package com.github.manevolent.ffmpeg4j.transcoder;
 
 import com.github.manevolent.ffmpeg4j.AudioFrame;
 import com.github.manevolent.ffmpeg4j.Logging;
+import com.github.manevolent.ffmpeg4j.MediaStream;
 import com.github.manevolent.ffmpeg4j.VideoFrame;
 import com.github.manevolent.ffmpeg4j.filter.audio.AudioFilter;
 import com.github.manevolent.ffmpeg4j.filter.audio.AudioFilterNone;
@@ -147,6 +148,10 @@ public class Transcoder {
             for (VideoFrame frame : videoFrames)
                 for (VideoFrame filteredFrame : videoFilter.apply(frame))
                     targetStream.getVideoTargetStream().write(filteredFrame);
+    }
+
+    public double getTotalPosition() {
+        return sourceStream.getSubstreams().stream().mapToDouble(MediaStream::getPosition).sum();
     }
 
     public static void convert(SourceStream sourceStream, TargetStream targetStream,


### PR DESCRIPTION
Hi!
Thank you for this library, it provides almost all of the features I'm looking for!

As I've noticed, it would be helpful to be able to retrieve the total position across all source streams to be able to calculate a transcoding progress ratio. Or, even better, a way to retrieve the current progress from the transcoder either via passing a callback method or a getter.

I've tried my luck at implementing a simple getter method for the position. During testing I divided it by the sum of all packet durations to get a total progress ratio, which seemed to work out fine.

Unfortunately, I am not as familiar with the whole library (or JavaCV) yet - would it somehow be possible to retrieve the total duration of all streams before handling the packets inside the transcoder class?